### PR TITLE
Remove dummy fs dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
   "homepage": "https://github.com/DashCruft/discord.js-meme#readme",
   "dependencies": {
     "discord.js": "^12.3.1",
-    "fs": "0.0.1-security",
     "got": "^11.6.0"
   }
 }


### PR DESCRIPTION
The fs package on npm is a dummy module that actually does nothing, so it is a waste of a dependency.

Fix #12 